### PR TITLE
Do not pull in default features of `image`

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-image = "0.25.2"
+image = { version = "0.25.2", default-features = false }
 pic-scale-safe = {path = "../", features = []}
 fast_image_resize = { version = "5.0.0", features = [] }
 


### PR DESCRIPTION
You only need the buffer types, so no need to unconditionally pull in all the format decoders into the dependency tree.