### PR TITLE
Improved nearest interpolation

### DIFF
--- a/src/resize_nearest.rs
+++ b/src/resize_nearest.rs
@@ -39,11 +39,12 @@ pub(crate) fn resize_nearest<T: Copy + Send + Sync, const CHANNELS: usize>(
     dst_width: usize,
     dst_height: usize,
 ) {
-    let x_scale = src_width as f32 / dst_width as f32;
-    let y_scale = src_height as f32 / dst_height as f32;
+    const SHIFT: i32 = 32;
 
-    let clip_width = src_width as f32 - 1f32;
-    let clip_height = src_height as f32 - 1f32;
+    let k_x: u64 = ((src_width as u64) << SHIFT) / dst_width as u64;
+    let k_y: u64 = ((src_height as u64) << SHIFT) / dst_height as u64;
+    let k_x_half: u64 = k_x >> 1;
+    let k_y_half: u64 = k_y >> 1;
 
     let dst_stride = dst_width * CHANNELS;
     let src_stride = src_width * CHANNELS;
@@ -59,14 +60,13 @@ pub(crate) fn resize_nearest<T: Copy + Send + Sync, const CHANNELS: usize>(
     }
 
     iter.enumerate().for_each(|(y, dst_row)| {
-        for (x, dst_chunk) in dst_row.chunks_exact_mut(CHANNELS).enumerate() {
-            let src_x = ((x as f32 + 0.5f32) * x_scale - 0.5f32)
-                .min(clip_width)
-                .max(0f32) as usize;
-            let src_y = ((y as f32 + 0.5f32) * y_scale - 0.5f32)
-                .min(clip_height)
-                .max(0f32) as usize;
-            let src_offset_y = src_y * src_stride;
+        let src_y = ((y as u64 * k_y + k_y_half) >> SHIFT) as usize;
+        let src_offset_y = src_y * src_stride;
+
+        let mut src_x_fixed = k_x_half;
+        for dst_chunk in dst_row.chunks_exact_mut(CHANNELS) {
+            let src_x = (src_x_fixed >> SHIFT) as usize;
+
             let src_px = src_x * CHANNELS;
             let offset = src_offset_y + src_px;
 
@@ -75,6 +75,8 @@ pub(crate) fn resize_nearest<T: Copy + Send + Sync, const CHANNELS: usize>(
             for (src, dst) in src_slice.iter().zip(dst_chunk.iter_mut()) {
                 *dst = *src;
             }
+
+            src_x_fixed += k_x;
         }
     });
 }


### PR DESCRIPTION
I changed the implementation of NN interpolation to improve it in two ways: fixed point and better rounding.

### Better rounding

I fixed a minor rounding issue in the way coordinates were mapped to the source image. It used to do the following (using the X coord here, Y has the same issue):

```rs
let x_scale = src_width as f32 / dst_width as f32;
let clip_width = src_width as f32 - 1f32;
let src_x = ((dst_x as f32 + 0.5f32) * x_scale - 0.5f32).min(clip_width).max(0f32) as usize;
```

which is mathematically equivalent to:

$$
src_x = \lfloor \max(0, \min(src_w-1, (dst_x + 0.5) * src_w / dst_w - 0.5)) \rfloor
$$

The problem is that `as usize` performs truncation (or here flooring) to get an integer. This is incorrect, because we want the *nearest* source pixel. In other words, it should have been `.round() as usize`.

Of course, rounding to nearest for numbers $r>-0.5$ is just $\lfloor r +0.5 \rfloor$, so we actually just remove the `- 0.5` to get rounding to the nearest integer. So:

```rs
let x_scale = src_width as f32 / dst_width as f32;
let clip_width = src_width as f32 - 1f32;
let src_x = ((dst_x as f32 + 0.5f32) * x_scale).min(clip_width) as usize;
```

This would be correct. 

### Fixed point

Firstly, I switched to a fixed-point arithmetic approach to avoid floating point. This means that FP rounding error is a non-issue and that costly FP operations can be avoided. This alone should make nearest interpolation a fair bit faster now.

The code for coords works similar to the FP version. Instead of a `scale` variable, it's `k` and `k_half`.

```rs
let k_y: u64 = ((src_height as u64) << SHIFT) / dst_height as u64;
let k_y_half: u64 = k_y >> 1;
let src_y = ((dst_y as u64 * k_y + k_y_half) >> SHIFT) as usize;
```

Ignoring the `SHIFT` for now, this is correct because:

$$
src_y = round((dst_y + 0.5) * k_y - 0.5) = \lfloor (dst_y + 0.5) * k_y \rfloor = \lfloor dst_y * k_y + \frac{k_y}{2} \rfloor
$$

Back to `SHIFT`: I used 32 bits for the fractional part. This should be accurate enough so that all results are exact for all images with dimensions <2^31. For dimensions >=2^31 and <2^32, I expect minor rounding issues. For dimensions >=2^32, overflow will occur and results will be wildly incorrect. I think this is acceptable, since the `f32` version suffered from rounding issues for dimensions >2^24 (and I'm not sure if dimensions >`u32::MAX` are worth supporting).

Also, the computation for `src_x` is a bit more obfuscated, because I avoided a multiplication by just adding `k_x` on every loop iteration to make things faster.

----

As for tests and benchmarks... how do they work in this repo?